### PR TITLE
replace initialize_all_variables with global_variables_initializer and ...

### DIFF
--- a/g3doc/get_started/basic_usage.md
+++ b/g3doc/get_started/basic_usage.md
@@ -213,7 +213,7 @@ update = tf.assign(state, new_value)
 
 # Variables must be initialized by running an `init` Op after having
 # launched the graph.  We first have to add the `init` Op to the graph.
-init_op = tf.initialize_all_variables()
+init_op = tf.global_variables_initializer()
 
 # Launch the graph and run the ops.
 with tf.Session() as sess:

--- a/g3doc/get_started/index.md
+++ b/g3doc/get_started/index.md
@@ -27,7 +27,7 @@ optimizer = tf.train.GradientDescentOptimizer(0.5)
 train = optimizer.minimize(loss)
 
 # Before starting, initialize the variables.  We will 'run' this first.
-init = tf.initialize_all_variables()
+init = tf.global_variables_initializer()
 
 # Launch the graph.
 sess = tf.Session()
@@ -40,6 +40,9 @@ for step in range(201):
         print(step, sess.run(W), sess.run(b))
 
 # Learns best fit is W: [0.1], b: [0.3]
+
+# Close the Session when we're done.
+sess.close()
 ```
 
 코드의 앞 부분은 데이터 플로우 그래프를 만들고 있습니다. 텐서플로우는 세션이 만들어져서 `run` 함수가 호출되기 전까지 어떤 것도 실제로 실행하지 않습니다.

--- a/g3doc/tutorials/mnist/beginners/index.md
+++ b/g3doc/tutorials/mnist/beginners/index.md
@@ -189,7 +189,7 @@ train_step = tf.train.GradientDescentOptimizer(0.5).minimize(cross_entropy)
 이제 우리 모델은 학습할 준비가 되었습니다. 학습을 실행시키기 전에 마지막으로, 우리가 작성한 변수들을 초기화하는 작업을 추가해야 합니다:
 
 ```python
-init = tf.initialize_all_variables()
+init = tf.global_variables_initializer()
 ```
 
 이제 `Session`에서 모델을 실행시키고, 변수들을 초기화 하는 작업을 실행시킬 수 있습니다:

--- a/g3doc/tutorials/mnist/pros/index.md
+++ b/g3doc/tutorials/mnist/pros/index.md
@@ -240,7 +240,7 @@ cross_entropy = tf.reduce_mean(-tf.reduce_sum(y_ * tf.log(y_conv), reduction_ind
 train_step = tf.train.AdamOptimizer(1e-4).minimize(cross_entropy)
 correct_prediction = tf.equal(tf.argmax(y_conv,1), tf.argmax(y_,1))
 accuracy = tf.reduce_mean(tf.cast(correct_prediction, tf.float32))
-sess.run(tf.initialize_all_variables())
+sess.run(tf.global_variables_initializer())
 for i in range(20000):
   batch = mnist.train.next_batch(50)
   if i%100 == 0:

--- a/g3doc/tutorials/mnist/pros/index.md
+++ b/g3doc/tutorials/mnist/pros/index.md
@@ -70,7 +70,7 @@ b = tf.Variable(tf.zeros([10]))
 `Variable`들은 세션이 시작되기 전에 초기화되어야 합니다. 아래 코드는 모든 `Variable`들 각각에 대해 미리 지정된 초기 값(위에서 지정된 0으로만 구성된 텐서)를 넣어 주는 역할을 합니다.
 
 ```python
-sess.run(tf.initialize_all_variables())
+sess.run(tf.global_variables_initializer())
 ```
 
 ### 클래스 예측 및 비용 함수(Cost Function)


### PR DESCRIPTION
replace initialize_all_variables with global_variables_initializer and add session close call in get_started/index.md

get_started/index.md 
: 마지막 부분 sess.close() 추가
=> 기존 문서에서 sess.close()가 추가 되서 한글 문서에도 추가 했습니다.

-------------------------------------------------------------------------------------------
get_started/basic_usage.md 
tutorial/mnist/beginners/index.md
tutorial/mnist/pros/index.md

: initialize_all_variables에서 global_variables_initializer 로 변경

---------------------------------------------------------------------------------------------
텐서 플로우 코드를 보다가 

tensorflow/tensorflow/python/ops/state_ops.py 이 파일에서 

다음과 같은 주석을 발견했습니다.
# Deprecated functions (removed after 2017-03-02). Please don't use them.
@@all_variables
@@initialize_all_variables
@@initialize_local_variables
@@initialize_variables

문서를 확인 해 보니 최신 업데이트 버전부터는
 initialize_all_variables 대신 global_variables_initializer 사용을 권장하는 것 같습니다.

---------------------------------------------------------------------------------------------
시간이 없어서 많이 수정을 못했습니다. 죄송합니다. 
시간이 나는데로 다른 부분도 찾아서 수정 하겠습니다.